### PR TITLE
fix `>osc` for factor 0.99

### DIFF
--- a/osc/osc.factor
+++ b/osc/osc.factor
@@ -11,9 +11,9 @@ GENERIC: >osc* ( obj -- data type-tag )
 M: object >osc* >byte-array "b" ;
 M: string >osc* pad-osc-string "s" ;
 M: fixnum >osc* 1array "i" pack-be "i" ;
-! M: float >osc* write-float "f" ;
+M: float >osc* big-endian [ write-float ] with-endianness "f" ;
 ! M: float >osc* big-endian [ write-double ] with-endianness "d" ;
-M: float >osc* 1array "d" pack-be "d" ;
+! M: float >osc* 1array "d" pack-be "d" ;
 M: boolean >osc* "T" "F" ? B{ } swap ;
 M: +nil+ >osc* drop B{ } "N" ;
 CONSTANT: reftime T{ timestamp

--- a/osc/osc.factor
+++ b/osc/osc.factor
@@ -34,10 +34,10 @@ M: immediately >osc*
 ! M: sequence >osc*
 
 : >osc ( seq -- bytes tag-str )
-    [ B{  } "," ]
-    [ [ >osc* ] [ swapd [ append ] 2dip append ] map-reduce "," prepend ]
-    if-empty
-    ;
+    [ B{ } "," ]
+    [ [ >osc* 2array ] map flip
+      [ first concat ] [ last concat ] bi "," prepend ]
+    if-empty ;
 
 : osc-message ( pattern args -- bytes )
     [ >osc* drop ] [ >osc >osc* drop ] bi* swap append append ;


### PR DESCRIPTION
I'm not sure if `>osc` worked in previous versions of Factor but it wasn't working in the git version (0.99) for me. With this change, it works again and I'm able to send OSC as expected.